### PR TITLE
Event proposal dialog clear date buttons

### DIFF
--- a/components/event-proposal-dialog.tsx
+++ b/components/event-proposal-dialog.tsx
@@ -138,7 +138,7 @@ export function EventProposalDialog({ group }: { group: number }) {
                 id="name"
                 type="text"
                 name="name"
-                placeholder="Event Name"
+                placeholder="Event name"
                 value={title}
                 onChange={handleEventNameChange}
                 className={
@@ -155,6 +155,7 @@ export function EventProposalDialog({ group }: { group: number }) {
                 id="description"
                 type="text"
                 name="description"
+                placeholder="Event description"
                 value={desc}
                 onChange={handleEventDescChange}
               />


### PR DESCRIPTION
Fixes #103 

## Changes

- Add buttons to clear date inputs on event proposal dialog
- Use `useRef` to handle date inputs in order to update browser's DOM on clear